### PR TITLE
fix: Missing Mode of Collection values in Trusts England rows

### DIFF
--- a/src/fft/config.py
+++ b/src/fft/config.py
@@ -569,3 +569,26 @@ SUMMARY_COLUMNS = {
         "is_extremely_unlikely": " IS Extremely Unlikely",
     },
 }
+
+# =============================================================================
+# VALIDATION CONFIGURATION
+# =============================================================================
+
+# Tolerance for floating point comparisons during validation
+VALIDATION_TOLERANCE: float = 1e-8
+
+# Provider type constants
+IS1_CODE = "IS1"
+IS1_NAME = "INDEPENDENT SECTOR PROVIDERS"
+NHS_PROVIDER_KEYWORDS = ["NHS", "TRUST"]
+
+# Sheet and data markers
+SUPPRESSION_MARKER = "*"
+
+# England rows column skip counts for Mode of Collection fix
+ENGLAND_ROWS_SKIP_COLUMNS = {
+    "ICB": 2,
+    "Trusts": 3,
+    "Sites": 4,
+    "Wards": 5,
+}

--- a/src/fft/writers.py
+++ b/src/fft/writers.py
@@ -9,6 +9,7 @@ from openpyxl.workbook import Workbook
 
 from fft.config import (
     BS_SHEET_CONFIG,
+    ENGLAND_ROWS_SKIP_COLUMNS,
     OUTPUT_COLUMNS,
     OUTPUTS_DIR,
     PERCENTAGE_COLUMN_CONFIG,
@@ -414,19 +415,9 @@ def write_england_totals(
         # Get output columns for this sheet to determine positioning
         output_cols = OUTPUT_COLUMNS[service_type].get(sheet_name, [])
 
-        # Find the index where data columns start (after geographic identifiers)
-        data_columns = [
-            "Total Responses",
-            "Total Eligible",
-            "Percentage_Positive",
-            "Percentage_Negative",
-            "Very Good",
-            "Good",
-            "Neither Good nor Poor",
-            "Poor",
-            "Very Poor",
-            "Don't Know",
-        ]
+        # Extract data columns dynamically from config (exclude geographic identifiers)
+        skip_cols = ENGLAND_ROWS_SKIP_COLUMNS.get(sheet_name, 0)
+        data_columns = output_cols[skip_cols:]
 
         # Row 12: England (including IS)
         name_col_idx = output_cols.index(sheet_config["england_label_column"]) + 1


### PR DESCRIPTION
- Add ENGLAND_ROWS_SKIP_COLUMNS config for dynamic column extraction
- Update write_england_totals to use sheet-specific column skipping
- Resolves #40: Mode of Collection columns now populated in England rows

(Excuse the GitHub Copilot brevity :arrow_up: )